### PR TITLE
Fix quotes in file selector to avoid spaces breaking HTML

### DIFF
--- a/soundscape.js
+++ b/soundscape.js
@@ -79,25 +79,6 @@ Hooks.on("renderSidebarTab", (app, html) => {
         btn.on("click",async event => {
             mixer.renderApp(true);
         });
-
-        let soundElements = document.getElementsByClassName('sound-name');
-        for (let elem of soundElements) {
-            const playlist = elem.parentElement.getAttribute('data-playlist-id');
-            const sound = elem.parentElement.getAttribute('data-sound-id');
-            if (playlist == undefined || sound == undefined) continue;
-            elem.draggable = true;
-            
-            elem.ondragstart = (event) => {
-                const data = {
-                        type: 'playlist_single',
-                        playlist,
-                        sound,
-                        draggedSound: sound
-                    }
-                event.dataTransfer.effectAllowed = 'move';
-                event.dataTransfer.setData('text/plain', JSON.stringify(data));
-            }; 
-        }
     }
 });
 

--- a/src/Channels/channel.js
+++ b/src/Channels/channel.js
@@ -163,7 +163,7 @@ export class Channel {
             if (playlist == undefined) return;
             const sound = playlist.sounds.getName(soundData.soundName);
             if (sound == undefined) return;
-            soundArray.push(sound.data.path)
+            soundArray.push(sound.path)
             soundData.randomize = false;
         }
         else if (soundData.soundSelect == 'playlist_multi') {
@@ -172,7 +172,7 @@ export class Channel {
             
             //Add all sounds in playlist to array
             for (let sound of playlist.sounds) 
-                soundArray.push(sound.data.path)  
+                soundArray.push(sound.path)  
         }
         else if (soundData.soundSelect == 'filepicker_single') {
             const source = soundData.source;

--- a/src/Channels/soundConfig.html
+++ b/src/Channels/soundConfig.html
@@ -135,7 +135,7 @@
                 <button type="button" class="file-picker" data-type="audio" data-target="src" title="Browse Files" tabindex="-1">
                     <i class="fas fa-file-import fa-fw"></i>
                 </button>
-                <input class="image" type="text" name="src" name2="soundSrc" id="srcPath" placeholder="path/audio.mp3" value={{channel.soundData.source}}>
+                <input class="image" type="text" name="src" name2="soundSrc" id="srcPath" placeholder="path/audio.mp3" value="{{channel.soundData.source}}">
             </div>
         </div>
 
@@ -145,7 +145,7 @@
                 <button type="button" class="file-picker" data-type="folder" data-target="folderSrc" title="Browse Files" tabindex="-1">
                     <i class="fas fa-file-import fa-fw"></i>
                 </button>
-                <input class="image" type="text" name="folderSrc" name2="folderSrc" id="srcFolderPath" placeholder="path/folder" value={{channel.soundData.source}}>
+                <input class="image" type="text" name="folderSrc" name2="folderSrc" id="srcFolderPath" placeholder="path/folder" value="{{channel.soundData.source}}">
             </div>
         </div>
 

--- a/src/Mixer/mixerApp.js
+++ b/src/Mixer/mixerApp.js
@@ -174,16 +174,21 @@ export class MixerApp extends FormApplication {
             target.style.borderColor = 'black';
             const targetId = target.id.replace('box-','')
             
-            let data = event.originalEvent.dataTransfer.getData('text/plain');
-            try{
-                data = JSON.parse(data);
-            } catch (e) {
-                return;
-            }
+            let data = TextEditor.getDragEventData(event.originalEvent)
+            let sound = fromUuidSync(data.uuid)
             if (data.type == 'Playlist') {
+                
                 data = {
                     type: "playlist_multi",
-                    playlist: data.id
+                    playlist: sound.id
+                }
+            }
+            if (data.type == "PlaylistSound"){
+                data = {
+                    type: "playlist_single",
+                    playlist: sound.parent.id,
+                    sound: sound.id,
+                    draggedSound: sound.id
                 }
             }
             this.mixer.newData(targetId,data);
@@ -210,21 +215,26 @@ export class MixerApp extends FormApplication {
             if (target.id == this.dragging) return;
             target.style.borderColor = 'black';
             const targetId = target.id.replace('sbButton-','')
-
-            let data = event.originalEvent.dataTransfer.getData('text/plain');
-
-            try{
-                data = JSON.parse(data);
-            } catch (e) {
+            let data = TextEditor.getDragEventData(event.originalEvent)
+            if (!["PlaylistSound","Playlist"].includes(data.type)){
                 const sourceId = this.dragging.replace('sbButton-','')
                 if (this.controlDown) this.mixer.soundboard.copySounds(sourceId,targetId);
                 else this.mixer.soundboard.swapSounds(sourceId,targetId);
                 return;
             }
+            let sound = fromUuidSync(data.uuid)
             if (data.type == 'Playlist') {
                 data = {
                     type: "playlist_multi",
-                    playlist: data.id
+                    playlist: sound.id
+                }
+            }
+            if (data.type == "PlaylistSound"){
+                data = {
+                    type: "playlist_single",
+                    playlist: sound.parent.id,
+                    sound: sound.id,
+                    draggedSound: sound.id
                 }
             }
             this.mixer.soundboard.newData(targetId,data);

--- a/src/Soundboard/soundboard.js
+++ b/src/Soundboard/soundboard.js
@@ -125,7 +125,8 @@ export class Soundboard {
         if (channelSettings == null) channelSettings = this.newChannel(targetId);
         if (data.type == 'playlist_multi') {
             const plName = game.playlists.get(data.playlist).name;
-            if (channelSettings.name == undefined || channelSettings.name == "") channelSettings.name = plName;
+            //if (channelSettings.name == undefined || channelSettings.name == "") 
+            channelSettings.name = plName;
             channelSettings.soundData.playlistName = plName;
             channelSettings.soundData.soundSelect = data.type;
         }
@@ -134,7 +135,8 @@ export class Soundboard {
             if (pl == undefined) return;
             const plName = pl.name;
             const soundName = pl.sounds.get(data.sound).name;
-            if (channelSettings.name == undefined || channelSettings.name == "") channelSettings.name = soundName;
+            //if (channelSettings.name == undefined || channelSettings.name == "") 
+            channelSettings.name = soundName;
             channelSettings.soundData.playlistName = plName;
             channelSettings.soundData.soundName = soundName;
             channelSettings.soundData.soundSelect = data.type;


### PR DESCRIPTION
When this value is unquoted, spaces in a folder name break out of the context of the 'value' property and start adding additional properties to the element, breaking this input the next time it is loaded.