### PR TITLE
Restore the Soundscape button and slider in FVTT v13

### DIFF
--- a/soundscape.js
+++ b/soundscape.js
@@ -53,7 +53,7 @@ Hooks.on("renderApplicationV2", (app, html) => {
          * Create labels and buttons in sidebar
          */
         const volumeSlider = $(`
-            <li class="flexrow" data-tooltip="x">
+            <li class="flexrow" data-tooltip="Controls the local volume of music, ambience, and sound effects produced by the Soundscape module.">
                 <label>Soundscape</label>
                 <i class="volume-icon fa-solid fa-volume-low" inert></i>
                 <input class="global-volume-slider" style="flex: 2; height: unset;" name="soundscapeVolume" type="range" min="0" max="1" step="0.05" value="${game.settings.get(moduleName,'volume')}">

--- a/soundscape.js
+++ b/soundscape.js
@@ -56,10 +56,7 @@ Hooks.on("renderApplicationV2", (app, html) => {
             <li class="flexrow" data-tooltip="x">
                 <label>Soundscape</label>
                 <i class="volume-icon fa-solid fa-volume-low" inert></i>
-                <range-picker name="soundscapeVolume" value="${game.settings.get(moduleName,'volume')}" min="0" max="1" step="0.05" class="global-volume-slider" data-tooltip="65%" aria-label="Soundscape" aria-valuetext="Volume: 65%">
-                    <input type="range" min="0" max="1" step="0.05">
-                    <input type="number" min="0" max="1" step="0.05">
-                </range-picker>
+                <input class="global-volume-slider" style="flex: 2; height: unset;" name="soundscapeVolume" type="range" min="0" max="1" step="0.05" value="${game.settings.get(moduleName,'volume')}">
             </li>
             `
         );

--- a/soundscape.js
+++ b/soundscape.js
@@ -46,22 +46,25 @@ Hooks.once('ready',async ()=>{
     }
 })
 
-Hooks.on("renderSidebarTab", (app, html) => {
+Hooks.on("renderApplicationV2", (app, html) => {
     activeUser = game.settings.get(moduleName, 'targetPlayer') === game.user.name;
     if (app.options.id == 'playlists' || app.id == 'playlists') {
          /**
          * Create labels and buttons in sidebar
          */
         const volumeSlider = $(`
-            <li class="sound flexrow">
-                <h4 class="sound-name">Soundscape</h4>
-                <i class="volume-icon fas fa-volume-down"></i>
-                <input class="global-volume-slider" name="soundscapeVolume" type="range" min="0" max="1" step="0.05" value="${game.settings.get(moduleName,'volume')}">
+            <li class="flexrow" data-tooltip="x">
+                <label>Soundscape</label>
+                <i class="volume-icon fa-solid fa-volume-low" inert></i>
+                <range-picker name="soundscapeVolume" value="${game.settings.get(moduleName,'volume')}" min="0" max="1" step="0.05" class="global-volume-slider" data-tooltip="65%" aria-label="Soundscape" aria-valuetext="Volume: 65%">
+                    <input type="range" min="0" max="1" step="0.05">
+                    <input type="number" min="0" max="1" step="0.05">
+                </range-picker>
             </li>
             `
         );
-        $('#global-volume').find('.playlist-sounds').append(volumeSlider);
-        const vol = html.find("input[name=soundscapeVolume]");
+        $('.global-volume').find('ol.plain').append(volumeSlider);
+        const vol = $(html).find("input[name=soundscapeVolume]");
         vol.on("input change", event => {
             const volume = event.target.value;
             if (mixer != undefined) mixer.master.effects.interfaceGain.set(volume);
@@ -80,7 +83,7 @@ Hooks.on("renderSidebarTab", (app, html) => {
             </div>
             `
         );
-        html.find(".directory-header").prepend(btn);
+        $(html).find(".directory-header").prepend(btn);
         btn.on("click",async event => {
             mixer.renderApp(true);
         });
@@ -104,7 +107,7 @@ Hooks.on("renderSidebarTab", (app, html) => {
             }; 
         }
         */
-        
+       
     }
 });
 


### PR DESCRIPTION
The Soundscape button and slider on the Playlists sidebar no longer display in Foundry v13. This PR makes changes to restore access to the Soundscape interface and hopefully make this module fully compatible with v13.

- The `renderSidebarTab` hook is no longer recognized; changed this to `renderApplicationV2`.
- Formatting of the default volume sliders has changed; styles for the Soundscape slider have been updated to conform.

My limited testing suggests that the overall functionality of the module is intact. Therefore, I only changed the elements necessary to restore the button and volume slider to the Playlists sidebar.

P.S. There are still some deprecation warnings that do not impact the functionality of the module (yet), and which I may address in a separate PR.